### PR TITLE
Buscar materias con tildes

### DIFF
--- a/src/components/Materias.js
+++ b/src/components/Materias.js
@@ -23,11 +23,13 @@ const Materias = ({ materias, materiaSelected, setCodigoSelected, partialLoading
   const shownMaterias = React.useMemo(() => {
     return materias
       .sort((a, b) => b.reponames.size - a.reponames.size)
-      .filter((m) =>
-        nombreFilter
-          ? m.nombre.toLowerCase().includes(nombreFilter.toLowerCase()) || m.codigos.some(c => c.includes(nombreFilter))
-          : true
-      )
+      .filter((m) => {
+        const nombreFilterNormalizado = nombreFilter.normalize('NFD').replace(/\p{Diacritic}/gu, '').toLowerCase()
+        const nombreMateriaNormalizada = m.nombre.normalize('NFD').replace(/\p{Diacritic}/gu, '').toLowerCase()
+        return nombreFilter
+        ? nombreMateriaNormalizada.includes(nombreFilterNormalizado) || m.codigos.some(c => c.includes(nombreFilterNormalizado))
+        : true
+      })
   }, [materias, nombreFilter]);
 
 


### PR DESCRIPTION
Buenas. Este PR es una pequeña modificación al buscador:
Cuando, por ejemplo, buscás "f**i**sica" (sin tilde) como el nombre de la materia es "F**í**sica" (con tilde) no lo encuentra.

_Sin tilde_
![Ejemplo sin tilde](https://github.com/FdelMazo/FIUBA-Repos/assets/72094271/6088421d-b6a3-4ef3-9a47-972712355334)

_Con tilde_
![Ejemplo con tilde](https://github.com/FdelMazo/FIUBA-Repos/assets/72094271/9bc7e36c-9f90-40c9-a096-fcfc13577598)


 Lo que hice fue normalizar ([doc de normalize](https://developer.mozilla.org/es/docs/Web/JavaScript/Reference/Global_Objects/String/normalize) y [gist](https://gist.github.com/marcelo-ribeiro/abd651b889e4a20e0bab558a05d38d77#file-javascript-slugify-normalize-js)) tanto el nombre de la materia como el texto que se busca.
 
 _Sin tilde_
![Ejemplo sin tilde fork](https://github.com/FdelMazo/FIUBA-Repos/assets/72094271/f1ade599-83d7-4e07-a323-a55731337a52)

_Con tilde_
![Ejemplo con tilde fork](https://github.com/FdelMazo/FIUBA-Repos/assets/72094271/177abb13-2f6f-4312-9b88-79f7e3f14acc)

Cualquier comentario sobre el código es bienvenido.
Saludos.